### PR TITLE
修改ServiceInfo.Create()中得到shortName值的代码

### DIFF
--- a/src/ServerApi/Adnc.WebApi.Shared/ServiceInfo.cs
+++ b/src/ServerApi/Adnc.WebApi.Shared/ServiceInfo.cs
@@ -19,9 +19,11 @@ namespace Adnc.WebApi.Shared
             var assemblyName = assembly.GetName();
             var version = assemblyName.Version;
             var fullName = assemblyName.Name.ToLower();
-            var startIndex = fullName.IndexOf('.') + 1;
-            var endIndex = fullName.IndexOf('.', startIndex);
-            var shortName = fullName.Substring(startIndex, endIndex - startIndex);
+            //var startIndex = fullName.IndexOf('.') + 1;
+            //var endIndex = fullName.IndexOf('.', startIndex);
+            //var shortName = fullName.Substring(startIndex, endIndex - startIndex);
+            var splitFullName = fullName.Split(".");
+            var shortName = splitFullName[^2];
 
             return new ServiceInfo
             {


### PR DESCRIPTION
var fullName = assemblyName.Name.ToLower();
            //var startIndex = fullName.IndexOf('.') + 1;
            //var endIndex = fullName.IndexOf('.', startIndex);
            //var shortName = fullName.Substring(startIndex, endIndex - startIndex);
            var splitFullName = fullName.Split(".");
            var shortName = splitFullName[^2];

修改原因：如果项目名称为 xxx.yyy.zzz.ccc 使用以前的获取shortName的代码，将获取到 yyy 这样会导致，swagger 文档内容不显示